### PR TITLE
Metrics that aren't provided by CloudWatch natively

### DIFF
--- a/lib/alephant/cache.rb
+++ b/lib/alephant/cache.rb
@@ -29,10 +29,12 @@ module Alephant
         }
       )
 
+      logger.metric(:name => "CachePuts", :unit => "Count", :value => 1)
       logger.info("Cache.put: #{path}/#{id}")
     end
 
     def get(id)
+      logger.metric(:name => "CacheGets", :unit => "Count", :value => 1)
       logger.info("Cache.get: #{path}/#{id}")
       object = bucket.objects["#{path}/#{id}"]
 


### PR DESCRIPTION
![getinsertpic.com](http://media0.giphy.com/media/rIq6ASPIqo2k0/200.gif)

## Problem

CloudWatch doesn't provide metrics for S3

## Solution

We'll implement custom metrics for it instead