### PR TITLE
Fix content type typo

### DIFF
--- a/lib/alephant/cache.rb
+++ b/lib/alephant/cache.rb
@@ -50,7 +50,7 @@ module Alephant
     def get(id)
       object       = bucket.objects["#{path}/#{id}"]
       content      = object.read
-      content_type = object.content_type,
+      content_type = object.content_type
       meta_data    = object.metadata.to_h
 
       logger.metric "CacheGets"

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -26,19 +26,19 @@ describe Alephant::Cache do
     let(:num_object_in_path) { 100 }
     it "deletes all objects for a path" do
       filtered_object_collection = double()
-      filtered_object_collection
-        .should_receive(:delete_all)
+      expect(filtered_object_collection)
+        .to receive(:delete_all)
 
       s3_object_collection = double()
-      s3_object_collection
-        .should_receive(:with_prefix)
+      expect(s3_object_collection)
+        .to receive(:with_prefix)
         .with(path)
         .and_return(filtered_object_collection)
 
       s3_bucket = double()
-      s3_bucket.should_receive(:objects).and_return(s3_object_collection)
+      expect(s3_bucket).to receive(:objects).and_return(s3_object_collection)
 
-      AWS::S3.any_instance.stub(:buckets).and_return({ id => s3_bucket })
+      expect_any_instance_of(AWS::S3).to receive(:buckets).and_return({ id => s3_bucket })
 
       instance = subject.new(id, path)
       instance.clear
@@ -48,16 +48,16 @@ describe Alephant::Cache do
   describe "put(id, data)" do
     it "sets bucket path/id content data" do
       s3_object_collection = double()
-      s3_object_collection.should_receive(:write).with(:data, { :content_type => 'foo/bar', :metadata=>{} })
+      expect(s3_object_collection).to receive(:write).with(:data, { :content_type => 'foo/bar', :metadata=>{} })
 
       s3_bucket = double()
-      s3_bucket.should_receive(:objects).and_return(
+      expect(s3_bucket).to receive(:objects).and_return(
         {
           "path/id" => s3_object_collection
         }
       )
 
-      AWS::S3.any_instance.stub(:buckets).and_return({ id => s3_bucket })
+      expect_any_instance_of(AWS::S3).to receive(:buckets).and_return({ id => s3_bucket })
       instance = subject.new(id, path)
 
       instance.put(id, data, 'foo/bar')
@@ -67,18 +67,18 @@ describe Alephant::Cache do
   describe "get(id)" do
     it "gets bucket path/id content data" do
       s3_object_collection = double()
-      s3_object_collection.should_receive(:read).and_return("content")
-      s3_object_collection.should_receive(:content_type).and_return("foo/bar")
-      s3_object_collection.should_receive(:metadata).and_return({ :foo => :bar})
+      expect(s3_object_collection).to receive(:read).and_return("content")
+      expect(s3_object_collection).to receive(:content_type).and_return("foo/bar")
+      expect(s3_object_collection).to receive(:metadata).and_return({ :foo => :bar})
 
       s3_bucket = double()
-      s3_bucket.should_receive(:objects).and_return(
+      expect(s3_bucket).to receive(:objects).and_return(
         {
           "path/id" => s3_object_collection
         }
       )
 
-      AWS::S3.any_instance.stub(:buckets).and_return({ id => s3_bucket })
+      expect_any_instance_of(AWS::S3).to receive(:buckets).and_return({ id => s3_bucket })
 
       instance = subject.new(id, path)
       object_hash = instance.get(id)


### PR DESCRIPTION
## Problem

The s3 object being served is served with an incorrect content type.

```
Content-Type: ["text/html", {"msg_id"=>"218c6e49-ad5d-4542-b856-b0d2a4e3bcf4"}]; charset=UTF-8
```

This is causing files to be downloaded when viewing in the browser, and would also affect component polling.

I ran the specs first, and they failed. So the change to introduce JSON logging to this, which caused this issue, did not pass.

## Solution

Remove comma, that is after the content type setting. This is causing the next meta line, to be appended to the content type.

## Note

I have also updated the rspec tests to use a newer syntax, as I got deprecation warnings.

https://jira.dev.bbc.co.uk/browse/CONNPOL-3050

![](https://media0.giphy.com/media/4LgA7gSThPVVS/200w.gif)